### PR TITLE
enhance(scripts): adds collection script for rook-ceph

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -1,4 +1,7 @@
 #!/bin/bash
+BASE_COLLECTION_PATH="/must-gather"
+
+# TODO: Resources commnon to both noobaa and ceph can be collected here
 
 # Resource List
 resources=()
@@ -7,8 +10,11 @@ resources=()
 
 # Run the Collection of Resources using must-gather
 for resource in ${resources[@]}; do
-    /usr/bin/openshift-must-gather inspect ${resource}
+    /usr/bin/openshift-must-gather --base-dir=${BASE_COLLECTION_PATH} inspect ${resource} --all-namespaces
 done
 
 # Call other gather scripts
-/usr/bin/gather_noobaa_resources
+/usr/bin/gather_noobaa_resources ${BASE_COLLECTION_PATH}
+/usr/bin/gather_ceph_resources ${BASE_COLLECTION_PATH}
+
+exit 0

--- a/collection-scripts/gather_ceph_resources
+++ b/collection-scripts/gather_ceph_resources
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Expect base collection path as an argument
+BASE_COLLECTION_PATH=$1
+
+# Use PWD as base path if no argument is passed
+if [[ ${BASE_COLLECTION_PATH} == "" ]]; then
+    BASE_COLLECTION_PATH=$(pwd)
+fi
+
+CEPH_COLLLECTION_PATH="${BASE_COLLECTION_PATH}/ceph"
+
+ceph_resources=()
+
+ceph_resources+=(cephblockpools)
+ceph_resources+=(cephclusters)
+ceph_resources+=(cephfilesystems)
+ceph_resources+=(cephnfses)
+ceph_resources+=(cephobjectstores)
+ceph_resources+=(cephobjectstoreusers)
+
+# Inspecting ceph related custom resources for all namespaces 
+for resource in ${ceph_resources[@]}; do
+    /usr/bin/openshift-must-gather --base-dir=${CEPH_COLLLECTION_PATH} inspect ${resource} --all-namespaces
+done
+
+# Inspecting the namespace where ceph-cluster is installed
+for ns in $(oc get cephcluster --all-namespaces --no-headers | awk '{print $1}'); do
+    /usr/bin/openshift-must-gather --base-dir=${CEPH_COLLLECTION_PATH} inspect ns/${ns}
+done

--- a/collection-scripts/gather_noobaa_resources
+++ b/collection-scripts/gather_noobaa_resources
@@ -1,7 +1,14 @@
 #!/bin/bash
-BASE_COLLECTION_PATH="/must-gather"
-NOOBAA_COLLLECTION_PATH="${BASE_COLLECTION_PATH}/noobaa"
 
+# Expect base collection path as an argument
+BASE_COLLECTION_PATH=$1
+
+# Use PWD as base path if no argument is passed
+if [[ ${BASE_COLLECTION_PATH} == "" ]]; then
+    BASE_COLLECTION_PATH=$(pwd)
+fi
+
+NOOBAA_COLLLECTION_PATH="${BASE_COLLECTION_PATH}/noobaa"
 
 noobaa_resources=()
 
@@ -11,7 +18,7 @@ noobaa_resources+=(noobaabucketclass)
 
 # Run the Collection of NooBaa Resources using must-gather
 for resource in ${noobaa_resources[@]}; do
-    /usr/bin/openshift-must-gather inspect ${resource}
+    /usr/bin/openshift-must-gather inspect ${resource} --all-namespaces
 done
 
 


### PR DESCRIPTION
This commit adds collection scripts for rook-ceph for must gather. The resources which are currently getting inspected for the rook-ceph are:
```
-> cephblockpools
-> cephclusters
-> cephfilesystems
-> cephnfses
-> cephobjectstores
-> cephobjectstoreusers
```
** Note: The scripts may require some tuning to narrow down the relevant data collection.

Signed-off-by: Ashish Ranjan <aranjan@redhat.com> 