### PR TITLE
Adds support for ceph-medic

### DIFF
--- a/.cephmedic.conf
+++ b/.cephmedic.conf
@@ -1,0 +1,2 @@
+[global]
+deployment_type = openshift

--- a/Centos-Base.repo
+++ b/Centos-Base.repo
@@ -1,0 +1,6 @@
+[centos]
+name=CentOS-7
+baseurl=http://ftp.heanet.ie/pub/centos/7/os/x86_64/
+enabled=1
+gpgcheck=1
+gpgkey=http://ftp.heanet.ie/pub/centos/7/os/x86_64/RPM-GPG-KEY-CentOS-7

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,24 @@
 FROM quay.io/openshift/origin-must-gather:latest
 
+RUN sed -i 's/enabled=1/enabled=0/g' /etc/yum/pluginconf.d/subscription-manager.conf \
+    && cat /etc/yum/pluginconf.d/subscription-manager.conf \
+    && sed -i 's/enabled=1/enabled=0/g' /etc/yum/pluginconf.d/ovl.conf && cat /etc/yum/pluginconf.d/ovl.conf \
+    && sed -i 's/enabled=1/enabled=0/g' /etc/yum/pluginconf.d/product-id.conf && cat /etc/yum/pluginconf.d/product-id.conf \
+    && sed -i 's/enabled=1/enabled=0/g' /etc/yum/pluginconf.d/search-disabled-repos.conf && cat /etc/yum/pluginconf.d/search-disabled-repos.conf \
+    && rm -rf /etc/yum.repos.d/*
+
+COPY Centos-Base.repo  /etc/yum.repos.d/
+COPY .cephmedic.conf /root/.cephmedic.conf
+
+RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm \
+    && yum -y install https://centos7.iuscommunity.org/ius-release.rpm \
+    && yum -y update \
+    && yum -y install python36u python36u-libs python36u-devel python36u-pip \
+    && ln -s /usr/bin/python3.6 /usr/bin/python3 \
+    && curl -LO https://github.com/ceph/ceph-medic/archive/master.tar.gz && tar xvzf master.tar.gz \ 
+    && cd ceph-medic-master && python3.6 setup.py install \
+    && rm -rf ceph-medic-master master.tar.gz
+
 # Save original gather script
 RUN mv /usr/bin/gather /usr/bin/gather_original
 

--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -1,8 +1,6 @@
 #!/bin/bash
 BASE_COLLECTION_PATH="/must-gather"
 
-# TODO: Resources commnon to both noobaa and ceph can be collected here
-
 # Resource List
 resources=()
 

--- a/collection-scripts/gather_ceph_resources
+++ b/collection-scripts/gather_ceph_resources
@@ -28,3 +28,5 @@ done
 for ns in $(oc get cephcluster --all-namespaces --no-headers | awk '{print $1}'); do
     /usr/bin/openshift-must-gather --base-dir=${CEPH_COLLLECTION_PATH} inspect ns/${ns}
 done
+
+ceph-medic check | tee ${CEPH_COLLLECTION_PATH}/ceph-medic-report.txt


### PR DESCRIPTION
This commit adds support for ceph-medic in must-gather.

Note: Ceph-medic currently takes a while, so currently it is not a good idea to invoke it through the gather script.

Signed-off-by: Ashish Ranjan <aranjan@redhat.com>
